### PR TITLE
Fix the link to "Guide to R Development"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ navigation:
   - title: Tutorials
     url: tutorials
   - title: Guide to R Development
-    url: https://forwards.github.io/rdevguide/
+    url: https://contributor.r-project.org/rdevguide/
   - title: R Contribution Working Group
     url: working-group
   - title: R Developer Page


### PR DESCRIPTION
I guess this is the correct one.